### PR TITLE
Remove dead substitution

### DIFF
--- a/src/Language/Sprite/L1/Check.hs
+++ b/src/Language/Sprite/L1/Check.hs
@@ -78,12 +78,10 @@ check :: Env -> SrcExpr -> RType -> CG SrcCstr
 
  -}
 check g (EFun bx e l) (TFun y s t) | y == x = do 
-  c     <- check (extEnv g bx s') e t'
+  c     <- check (extEnv g bx s) e t
   return $ cAll l x s c
   where
     x  = bindId bx
-    s' = subst s y x 
-    t' = subst t y x
 
 {- [Chk-Let] 
 


### PR DESCRIPTION
Because y==x, the 'subst s y x' makes no difference.
This doesn't cause any real problem, other than taking the reader
a minute of wondering whether there may be special magic behind these
two lines.