### PR TITLE
Fix logical connective `&&`

### DIFF
--- a/src/Language/Sprite/L2/Parse.hs
+++ b/src/Language/Sprite/L2/Parse.hs
@@ -66,7 +66,7 @@ op =  (FP.reservedOp "*"    >> pure BTimes)
   <|> (FP.reservedOp "=="   >> pure BEq   )  
   <|> (FP.reservedOp ">"    >> pure BGt   )  
   <|> (FP.reservedOp ">="   >> pure BGe   )  
-  <|> (FP.reservedOp "&&"   >> pure BOr   )  
+  <|> (FP.reservedOp "&&"   >> pure BAnd  )  
   <|> (FP.reservedOp "||"   >> pure BOr   )  
 
 bop :: PrimOp -> SrcImm -> SrcImm -> F.SrcSpan -> SrcExpr

--- a/src/Language/Sprite/L3/Parse.hs
+++ b/src/Language/Sprite/L3/Parse.hs
@@ -78,7 +78,7 @@ op =  (FP.reservedOp "*"    >> pure BTimes)
   <|> (FP.reservedOp "=="   >> pure BEq   )  
   <|> (FP.reservedOp ">"    >> pure BGt   )  
   <|> (FP.reservedOp ">="   >> pure BGe   )  
-  <|> (FP.reservedOp "&&"   >> pure BOr   )  
+  <|> (FP.reservedOp "&&"   >> pure BAnd  )  
   <|> (FP.reservedOp "||"   >> pure BOr   )  
 
 bop :: PrimOp -> SrcImm -> SrcImm -> F.SrcSpan -> SrcExpr

--- a/src/Language/Sprite/L4/Parse.hs
+++ b/src/Language/Sprite/L4/Parse.hs
@@ -78,7 +78,7 @@ op =  (FP.reservedOp "*"    >> pure BTimes)
   <|> (FP.reservedOp "=="   >> pure BEq   )  
   <|> (FP.reservedOp ">"    >> pure BGt   )  
   <|> (FP.reservedOp ">="   >> pure BGe   )  
-  <|> (FP.reservedOp "&&"   >> pure BOr   )  
+  <|> (FP.reservedOp "&&"   >> pure BAnd  )  
   <|> (FP.reservedOp "||"   >> pure BOr   )  
 
 bop :: PrimOp -> SrcImm -> SrcImm -> F.SrcSpan -> SrcExpr

--- a/src/Language/Sprite/L5/Parse.hs
+++ b/src/Language/Sprite/L5/Parse.hs
@@ -130,7 +130,7 @@ op =  (FP.reservedOp "*"    >> pure BTimes)
   <|> (FP.reservedOp "=="   >> pure BEq   )  
   <|> (FP.reservedOp ">"    >> pure BGt   )  
   <|> (FP.reservedOp ">="   >> pure BGe   )  
-  <|> (FP.reservedOp "&&"   >> pure BOr   )  
+  <|> (FP.reservedOp "&&"   >> pure BAnd  )  
   <|> (FP.reservedOp "||"   >> pure BOr   )  
 
 bop :: PrimOp -> SrcImm -> SrcImm -> F.SrcSpan -> SrcExpr

--- a/src/Language/Sprite/L6/Parse.hs
+++ b/src/Language/Sprite/L6/Parse.hs
@@ -148,7 +148,7 @@ op =  (FP.reservedOp "*"    >> pure BTimes)
   <|> (FP.reservedOp "=="   >> pure BEq   )  
   <|> (FP.reservedOp ">"    >> pure BGt   )  
   <|> (FP.reservedOp ">="   >> pure BGe   )  
-  <|> (FP.reservedOp "&&"   >> pure BOr   )  
+  <|> (FP.reservedOp "&&"   >> pure BAnd  )  
   <|> (FP.reservedOp "||"   >> pure BOr   )  
 
 bop :: PrimOp -> SrcImm -> SrcImm -> F.SrcSpan -> SrcExpr

--- a/src/Language/Sprite/L8/Parse.hs
+++ b/src/Language/Sprite/L8/Parse.hs
@@ -150,7 +150,7 @@ op =  (FP.reservedOp "*"    >> pure BTimes)
   <|> (FP.reservedOp "=="   >> pure BEq   )  
   <|> (FP.reservedOp ">"    >> pure BGt   )  
   <|> (FP.reservedOp ">="   >> pure BGe   )  
-  <|> (FP.reservedOp "&&"   >> pure BOr   )  
+  <|> (FP.reservedOp "&&"   >> pure BAnd  )  
   <|> (FP.reservedOp "||"   >> pure BOr   )  
 
 bop :: PrimOp -> SrcImm -> SrcImm -> F.SrcSpan -> SrcExpr


### PR DESCRIPTION
Currently in all L₂—L₈, both `&&` and `||` parse to `BOr`. I believe this is unintentional as there is a `BAnd` defined but not used.
It also causes confusion (it cost me a while of head-scratching trying to understand why some of my experiments weren't typechecking before I realized this was going on).