### PR TITLE
Perhaps `emptylist` is a better name than `singleton` in L₅/pos/nil00

### DIFF
--- a/test/L5/pos/nil00.re
+++ b/test/L5/pos/nil00.re
@@ -5,8 +5,8 @@ type list('a) =
   | Cons (x:'a, xs:list('a)) => [v| len v = 1 + len(xs)]
   ;
 
-/*@ val singleton : 'a => list('a)[v|len v = 0] */
-let singleton = (x) => {
+/*@ val emptylist : 'a => list('a)[v|len v = 0] */
+let emptylist = (x) => {
   let t = Nil;
   t
 };


### PR DESCRIPTION
...for a function returning an empty list.
I think this change makes the test less confusing to read.

(Note that in the neg counterpart, the function actually does compute an empty list while having singleton type, adding even more to the confusion.  I am not sure which name is better in *that* case).