### PR TITLE
Factor annotation and let id parsing through the same parser

### DIFF
--- a/src/Language/Sprite/L1/Parse.hs
+++ b/src/Language/Sprite/L1/Parse.hs
@@ -105,7 +105,7 @@ ann = (FP.reserved "/*@" >> (Just <$> annot)) <|> pure Nothing
 annot :: FP.Parser (F.Symbol, RType)
 annot = do
   FP.reserved "val"
-  x <- FP.lowerIdP
+  x <- identifier
   FP.colon
   t <- rtype
   FP.reservedOp "*/"

--- a/src/Language/Sprite/L2/Parse.hs
+++ b/src/Language/Sprite/L2/Parse.hs
@@ -132,7 +132,7 @@ ann = (reservedOp "/*@" >> (Just <$> annot)) <|> pure Nothing
 annot :: FP.Parser (F.Symbol, RType)
 annot = do
   reserved "val"
-  x <- FP.lowerIdP
+  x <- identifier
   colon
   t <- rtype
   reservedOp "*/"

--- a/src/Language/Sprite/L3/Parse.hs
+++ b/src/Language/Sprite/L3/Parse.hs
@@ -147,7 +147,7 @@ ann = (annL >> (Just <$> annot)) <|> pure Nothing
 annot :: FP.Parser (F.Symbol, RType)
 annot = do
   FP.reserved "val"
-  x <- FP.lowerIdP
+  x <- identifier
   FP.colon
   t <- rtype
   annR

--- a/src/Language/Sprite/L4/Parse.hs
+++ b/src/Language/Sprite/L4/Parse.hs
@@ -149,7 +149,7 @@ ann = (annL >> (Just <$> annot)) <|> pure Nothing
 annot :: FP.Parser (F.Symbol, RType)
 annot = do
   reserved "val"
-  x <- FP.lowerIdP
+  x <- identifier
   colon
   t <- rtype
   annR

--- a/src/Language/Sprite/L5/Parse.hs
+++ b/src/Language/Sprite/L5/Parse.hs
@@ -213,7 +213,7 @@ annR = reservedOp "*/"
 tyBindP :: String -> FP.Parser (F.Symbol, RType)
 tyBindP kw = do
   reserved kw
-  x <- FP.lowerIdP
+  x <- identifier
   colon
   t <- rtype
   annR

--- a/src/Language/Sprite/L6/Parse.hs
+++ b/src/Language/Sprite/L6/Parse.hs
@@ -231,7 +231,7 @@ annR = FP.reservedOp "*/"
 tyBindP :: String -> FP.Parser (F.Symbol, RType)
 tyBindP kw = do
   FP.reserved kw
-  x <- FP.lowerIdP
+  x <- identifier
   FP.colon
   t <- rtype
   annR

--- a/src/Language/Sprite/L8/Parse.hs
+++ b/src/Language/Sprite/L8/Parse.hs
@@ -237,7 +237,7 @@ annR = FP.reservedOp "*/"
 sigP :: String -> FP.Parser Sig
 sigP kw = do
   FP.reserved kw
-  x <- FP.lowerIdP
+  x <- identifier
   FP.colon
   t <- rtype
   m <- try (Just <$> metricP) <|> pure Nothing


### PR DESCRIPTION
This is a very trivial refactoring.

In an annotated let, the names in the annot and the let must match, which we check in mkDecl; and the token parsers themselves are both Fixpoint's lowerIdP, but in annot we reference FP.lowerIdP directly and plainDecl's binder factors through Common/Parse.hs:identifier. It makes no difference of course because identifier=FP.lowerIdP, but if someone is playing with changing 'identifier' in Common/Parse.hs then he will be confused by the difference.